### PR TITLE
feat: Add Practice Labs Topic

### DIFF
--- a/pages/academic-learning.tsx
+++ b/pages/academic-learning.tsx
@@ -23,5 +23,12 @@ export default function AcademicLearning() {
             description: "Study groups, mentorship programs, and collaborative learning environments",
             highlights: ["Study Groups", "Mentor Matching", "Code Reviews", "Discussion Forums"],
             status: "Planning"
+        },
+        {
+            name: "Practice Labs",
+            icon: "🔬",
+            description: "Sandbox environments for experimenting with smart contracts and DeFi protocols",
+            highlights: ["Testnet Integration", "Safe Experimentation", "Template Libraries", "Gas-free Testing"],
+            status: "In Progress"
         }
 }


### PR DESCRIPTION
# PR Title
feat: Add Practice Labs Topic to Academic Learning Page

# PR Description
## Summary
This PR adds a new **Practice Labs** topic to the `academic-learning.tsx` page, expanding the available learning modules.

## Changes
- Added **Practice Labs** section with:
  - 🔬 Icon for visual representation
  - Description emphasizing sandbox experimentation with smart contracts and DeFi protocols
  - Highlights including testnet integration, safe experimentation, template libraries, and gas-free testing
  - Status set to **In Progress**

## Motivation
The **Practice Labs** topic introduces a hands-on learning experience for users to safely explore blockchain development concepts in sandbox environments before deploying on mainnet. This aligns with the goal of providing both theoretical and practical learning paths in the Academic Learning module.
