### PR TITLE
feat: Add "Research Hub" section to Academic Learning page

### DIFF
--- a/pages/academic-learning.tsx
+++ b/pages/academic-learning.tsx
@@ -37,5 +37,12 @@ export default function AcademicLearning() {
             description: "Structured learning paths from beginner to advanced blockchain developer",
             highlights: ["Skill Assessments", "Custom Roadmaps", "Industry Projects", "Job Placement"],
             status: "Planning"
+        },
+        {
+            name: "Research Hub",
+            icon: "🔍",
+            description: "Access to cutting-edge research papers, whitepapers, and industry insights",
+            highlights: ["Research Database", "Expert Analysis", "Trend Reports", "Academic Partnerships"],
+            status: "Planning"
         }
-}
+    ];


### PR DESCRIPTION
# PR Description
### Summary
This PR adds the **final section** for the Academic Learning page: **Research Hub**.

### Changes
- Updated `pages/academic-learning.tsx`:
  - Added new entry: **Research Hub** with:
    - Icon: 🔍
    - Description: *"Access to cutting-edge research papers, whitepapers, and industry insights"*
    - Highlights:
      - Research Database
      - Expert Analysis
      - Trend Reports
      - Academic Partnerships
    - Status: *Planning*

### Impact
- Expands the Academic Learning roadmap with a dedicated **Research Hub**.
- Establishes foundation for future features like **research integration, academic collaborations, and curated resources**.
