### PR TITLE
feat: Add FAQ Section Return Statement with Styled HTML Header  

### DIFF
--- a/components/FAQ.tsx
+++ b/components/FAQ.tsx
@@ -44,4 +44,19 @@ export default function FAQ({ faqs = [] }) {
     const toggleFAQ = (index: SetStateAction<number>) => {
         setOpenIndex(openIndex === index ? -1 : index);
     };
-}
+
+    return (
+        <div className="py-16 bg-gradient-to-br from-white to-gray-50">
+            <div className="max-w-4xl mx-auto px-4">
+                <div className="text-center mb-12">
+                    <h2 className="text-4xl font-bold mb-4 bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent">
+                        Frequently Asked Questions
+                    </h2>
+                    <p className="text-xl text-gray-600">
+                        Everything you need to know about our platform
+                    </p>
+                </div>
+            
+            </div>
+        </div>
+)}


### PR DESCRIPTION
# PR Title  
✨ Add FAQ Section Return Statement with Styled HTML Header  

## Summary  
This PR introduces the **return structure** and **visually styled HTML header** for the `FAQ` React component. The update lays the groundwork for rendering the FAQ section on the front end with an engaging and responsive design.  

---

## Key Changes  
### 🧩 New UI Structure  
- **Added `return` statement** for component rendering.  
- Introduced a **container div** with gradient background and responsive padding (`py-16 bg-gradient-to-br from-white to-gray-50`).  
- Included a **centered header section** with:  
  - **Main heading (`<h2>`)** using gradient text styling (`from-blue-600 to-purple-600`).  
  - **Subheading (`<p>`)** providing a short contextual introduction.  

---

## Technical Details  
- The header layout uses TailwindCSS utility classes for modern, responsive styling.  
- Gradient text effects are achieved with `bg-clip-text` and `text-transparent` for a sleek visual appearance.  
- The return block is wrapped in a single `<div>` container to ensure clean composition for future FAQ item rendering.  

---

## Why This Change  
- **Enhances User Experience**: Adds visual appeal and structure to the FAQ section, making the page more engaging.  
- **Improves Readability**: Clear hierarchy through typography and spacing enhances content scanning.  
- **Prepares for Dynamic Content**: Sets up a container where individual FAQ items can be dynamically rendered next.  

---

## Next Steps  
- 🧱 Integrate FAQ items rendering beneath the header.  
- 🎨 Add animations or collapsible FAQ entries using the existing `toggleFAQ` logic.  
- ✅ Test responsiveness across device sizes.  

---

## Notes  
This commit transitions the `FAQ.tsx` component from logic-only to a **functional and styled render component**. It establishes the initial layout for a polished FAQ section that aligns with the platform’s design system.  
